### PR TITLE
Update sidebar collapse button repositioning

### DIFF
--- a/css/monks-little-details.css
+++ b/css/monks-little-details.css
@@ -164,8 +164,7 @@
     padding: 0px 3px;
 }
 #mldCharacterSound.loaded {
-    border: 1px solid #ff6400;
-        
+    border: 1px solid #ff6400;       
 }
 
 .mldCharacterName {
@@ -174,18 +173,8 @@
     align-items: center;
 }
 
-body.reposition-collapse #sidebar.collapsed #sidebar-tabs {
-    position: relative;
-}
-
-body.reposition-collapse #sidebar.collapsed #sidebar-tabs a:first-child {
-    margin-top: 27px;
-}
-
 body.reposition-collapse #sidebar.collapsed #sidebar-tabs a.collapse {
-    position: absolute;
-    top: 0px;
-    left: 10px;
+    order: -1;
 }
 
 body.reposition-collapse.system-wfrp4e #sidebar.collapsed #sidebar-tabs a.collapse {


### PR DESCRIPTION
Change the way repositioning the sidebar collapse button works, preserving the flexbox by simply using the `order` property.

This can probably be replicated on the WFRP4e rule, but I don't have it at the moment to test.