### PR TITLE
Allow blood-splatted token to be displayed under the splat

### DIFF
--- a/js/bloodsplats.js
+++ b/js/bloodsplats.js
@@ -110,7 +110,8 @@ export class BloodSplats {
                 }
             } else {
                 if (this.data._id != undefined) {
-                    this.icon.alpha = (game.user.isGM ? 0.2 : 0);
+                    if (!setting('bloodsplat-show-token'))
+                        this.icon.alpha = (game.user.isGM ? 0.2 : 0);
                     if (this.bloodsplat?.transform == undefined) {
                         if (this.bloodsplat)
                             this.removeChild(this.bloodsplat);

--- a/lang/en.json
+++ b/lang/en.json
@@ -89,6 +89,7 @@
 	"MonksLittleDetails.round-chatmessages.name": "Combat Round Messages",
 	"MonksLittleDetails.round-chatmessages.hint": "Add a chat message every round to delineate combat messages",
 	"MonksLittleDetails.bloodsplat-colour.name": "Bloodsplat colour",
+	"MonksLittleDetails.bloodsplat-show-token.name": "Show Token Under Bloodsplat",
 	"MonksLittleDetails.show-start.name": "Show start token",
 	"MonksLittleDetails.show-start.hint": "Show where the token started it's turn",
 	"MonksLittleDetails.sort-statuses.name": "Sort Statuses",

--- a/settings.js
+++ b/settings.js
@@ -5,7 +5,7 @@ export const registerSettings = function () {
 	let modulename = "monks-little-details";
 
 	const debouncedReload = foundry.utils.debounce(function () { window.location.reload(); }, 100);
-	
+
 	let dialogpositions = {
 		'': '—',
 		'topleft': 'Top Left',
@@ -515,6 +515,14 @@ export const registerSettings = function () {
 		config: true,
 		default: '#FF0000',
 		type: String,
+		onChange: debouncedReload
+	});
+	game.settings.register(modulename, "bloodsplat-show-token", {
+		name: i18n("MonksLittleDetails.bloodsplat-show-token.name"),
+		scope: "world",
+		config: true,
+		default: false,
+		type: Boolean,
 		onChange: debouncedReload
 	});
 	game.settings.register(modulename, "module-management-changes", {


### PR DESCRIPTION
This allows GMs who wish to still display the slain token the option to do so.