### PR TITLE
Fix actor sounds for DS4 system

### DIFF
--- a/js/actor-sounds.js
+++ b/js/actor-sounds.js
@@ -32,7 +32,11 @@ export class ActorSounds {
         let sheetNames = ["ActorSheet"];
 
         if (setting("actor-sounds") === "npc" || setting("actor-sounds") === 'true') {
-            let npcObject = (CONFIG.Actor.sheetClasses.npc || CONFIG.Actor.sheetClasses.minion);
+            let npcObject;
+            if (game.system.id == 'ds4') {
+                npcObject = CONFIG.Actor.sheetClasses.creature;
+            } else
+                npcObject = (CONFIG.Actor.sheetClasses.npc || CONFIG.Actor.sheetClasses.minion);
             if (npcObject != undefined) {
                 sheetNames = Object.values(npcObject)
                     .map((sheetClass) => sheetClass.cls)


### PR DESCRIPTION
Actor sheets for NPCs in DS4 are found in CONFIG.Actor.sheetClasses.creature instead of CONFIG.Actor.sheetClasses.npc. Taking this into account fixes the actor sound button appearing on all actor sheets even if "NPC-only" is requested.

Note that the DS4 system has not yet been ported to Foundry v10. However, these changes apply cleanly to monks-little-detail 1.0.55 which appears to be the latest version still supporting v9.