### PR TITLE
289: Force icon to be on the left.

### DIFF
--- a/css/monks-little-details.css
+++ b/css/monks-little-details.css
@@ -179,6 +179,7 @@ body.illandril-token-hud-scale--hud-button-scale #token-hud.monks-little-details
     padding: 0;
     opacity: 0.5;
     padding-right: calc(100% - 24px);
+    background-position-x: 0 !important;
 }
 
 .system-pf2e #token-hud.monks-little-details .status-effects .effect-control,


### PR DESCRIPTION
Fixes #289 