### PR TITLE
Fix condition labels not showing

### DIFF
--- a/js/hud-changes.js
+++ b/js/hud-changes.js
@@ -52,7 +52,7 @@ export class HUDChanges {
 
                     var condition = CONFIG.statusEffects.find(c => c.id == statusId);
                     if (condition)
-                        title = i18n(condition.name);
+                        title = condition.name ? i18n(condition.name) : i18n(condition.label);
 
                     $(img).removeAttr('data-tooltip');
 


### PR DESCRIPTION
The altered HUD status effects were missing their labels in D&D 4e. This fix reads the label from `condition.label` if `condition.name` is undefined.