### PR TITLE
(Effect HUD) Daggerheart System Compatability

### DIFF
--- a/css/monks-little-details.css
+++ b/css/monks-little-details.css
@@ -284,6 +284,10 @@ body.illandril-token-hud-scale--hud-button-scale #token-hud.monks-little-details
     opacity: 1;
 }
 
+#token-hud.monks-little-details .status-effects .palette-category-title {
+    grid-column: span 4;
+}
+
 .package-list .package .package-metadata .tag {
     padding: 0px 4px;
     border: 1px solid #2e6da4;

--- a/js/hud-changes.js
+++ b/js/hud-changes.js
@@ -51,7 +51,7 @@ export class HUDChanges {
 
                     $(img).removeAttr('data-tooltip');
 
-                    if (game.system.id == "pf2e") {
+                    if (["pf2e", "daggerheart"].includes(game.system.id)) {
                         $('<div>')
                             .addClass('effect-name')
                             .html(title)
@@ -62,7 +62,7 @@ export class HUDChanges {
                 }
             };
 
-            if (game.system.id !== 'pf2e' && setting("clear-all")) {
+            if (!["pf2e", "daggerheart"].includes(game.system.id) && setting("clear-all")) {
                 $('.col.right .status-effects', html).append(
                     $('<div>').addClass('clear-all').html(`<i class="fas fa-times-circle"></i> ${i18n("MonksLittleDetails.ClearAll")}`).on("click", HUDChanges.clearAll.bind(this))
                 );


### PR DESCRIPTION
Hey there. It was noted by a user a few days ago that the Daggerheart system's HUD effects didn't end up working with this module. There were minimal changes needed for compatability, so I figured I'd make a PR for them.

- Added column styling for daggerheart effect title so it's 4 columns wide with this module. 
- Daggerheart uses the same effect layout as pf2e, so I simply added on so the existing cases will run for the daggerheart system aswell.

There are a few classes being moved in the next daggerheart system patch that makes this work, so don't be suprised that it's not currently working. 😄 
EDIT: The newest version of the Daggerheart system is now set up for this to work.